### PR TITLE
Changing gazelle naming convention.

### DIFF
--- a/go/swagger/private/go_swagger_repository.bzl
+++ b/go/swagger/private/go_swagger_repository.bzl
@@ -49,7 +49,7 @@ def _go_swagger_repository_impl(ctx):
           fake_repo, result.stderr))
 
     gazelle = ctx.path(ctx.attr._gazelle)
-    cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix',
+    cmds = [gazelle, '--go_prefix', ctx.attr.importpath, '--mode', 'fix', "--go_naming_convention", "import_alias",
             '--repo_root', ctx.path('')]
     cmds += [ctx.path('')]
     result = env_execute(ctx, cmds)


### PR DESCRIPTION
Generate both foo/bar:bar and foo/bar:go_default_library targets to ease
transition to newer rules_go/gazelle.