### PR TITLE
Typo: the actual tag is "v0.1.0", not "0.1.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the following to your WORKSPACE file:
 git_repository(
     name = "com_github_tnarg_rules_go_swagger",
     remote = "https://github.com/tnarg/rules_go_swagger.git",
-    tag = "0.1.0",
+    tag = "v0.1.0",
 )
 
 load("@com_github_tnarg_rules_go_swagger//go/swagger:def.bzl", "go_swagger_deps", "go_swagger_repositories", "go_swagger_repository")


### PR DESCRIPTION
Validated change by using in a project.  Existing example in `README.md` doesn't work.  This character change allows that error to be passed.